### PR TITLE
Bugfix: jUnit xml output contains null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,6 +237,7 @@ Reporter.prototype = {
       this.xml[0].children[this.testIdx].children[this.testCount].children[this.variationCount].attrs.end = timestamp;
     }
 
+    this.lastAssertion = data;
     this.variationCount++;
     return this;
   },


### PR DESCRIPTION
jUnit xml output contains null values for attribute "end" in last test cases within a test suite.
