### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# DalekJS is not maintained any longer :cry:
+
+We recommend [TestCafé](http://devexpress.github.io/testcafe/) for your automated browser testing needs.
+
+---
+
 dalek-reporter-junit
 ====================
 


### PR DESCRIPTION
# DalekJS is not maintained any longer :cry:

We recommend [TestCafé](http://devexpress.github.io/testcafe/) for your automated browser testing needs.